### PR TITLE
Add default CMS collections

### DIFF
--- a/collections/Categories.ts
+++ b/collections/Categories.ts
@@ -1,0 +1,36 @@
+import { CollectionConfig } from 'payload/types';
+import { formatSlug } from '../utils/formatSlug';
+
+const Categories: CollectionConfig = {
+  slug: 'categories',
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      unique: true,
+      required: true,
+    },
+    {
+      name: 'description',
+      type: 'textarea',
+    },
+  ],
+  hooks: {
+    beforeValidate: [({ data }) => {
+      if (typeof data.name === 'string' && !data.slug) {
+        data.slug = formatSlug(data.name);
+      }
+      return data;
+    }],
+  },
+};
+
+export default Categories;

--- a/collections/Media.ts
+++ b/collections/Media.ts
@@ -1,0 +1,17 @@
+import { CollectionConfig } from 'payload/types';
+
+const Media: CollectionConfig = {
+  slug: 'media',
+  upload: true,
+  admin: {
+    useAsTitle: 'filename',
+  },
+  fields: [
+    {
+      name: 'alt',
+      type: 'text',
+    },
+  ],
+};
+
+export default Media;

--- a/collections/Pages.ts
+++ b/collections/Pages.ts
@@ -1,0 +1,55 @@
+import { CollectionConfig } from 'payload/types';
+import { formatSlug } from '../utils/formatSlug';
+
+const Pages: CollectionConfig = {
+  slug: 'pages',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      unique: true,
+      required: true,
+    },
+    {
+      name: 'layout',
+      type: 'richText',
+    },
+    {
+      name: 'status',
+      type: 'select',
+      options: [
+        {
+          label: 'Draft',
+          value: 'draft',
+        },
+        {
+          label: 'Published',
+          value: 'published',
+        },
+      ],
+      defaultValue: 'draft',
+    },
+    {
+      name: 'publishedDate',
+      type: 'date',
+    },
+  ],
+  hooks: {
+    beforeValidate: [({ data }) => {
+      if (typeof data.title === 'string' && !data.slug) {
+        data.slug = formatSlug(data.title);
+      }
+      return data;
+    }],
+  },
+};
+
+export default Pages;

--- a/collections/Posts.ts
+++ b/collections/Posts.ts
@@ -1,0 +1,67 @@
+import { CollectionConfig } from 'payload/types';
+import { formatSlug } from '../utils/formatSlug';
+import Users from './Users';
+import Categories from './Categories';
+import Tags from './Tags';
+import Media from './Media';
+
+const Posts: CollectionConfig = {
+  slug: 'posts',
+  admin: {
+    useAsTitle: 'title',
+  },
+  fields: [
+    {
+      name: 'title',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      unique: true,
+      required: true,
+    },
+    {
+      name: 'content',
+      type: 'richText',
+    },
+    {
+      name: 'excerpt',
+      type: 'textarea',
+    },
+    {
+      name: 'author',
+      type: 'relationship',
+      relationTo: Users.slug,
+      required: true,
+    },
+    {
+      name: 'categories',
+      type: 'relationship',
+      relationTo: Categories.slug,
+      hasMany: true,
+    },
+    {
+      name: 'tags',
+      type: 'relationship',
+      relationTo: Tags.slug,
+      hasMany: true,
+    },
+    {
+      name: 'featuredImage',
+      type: 'upload',
+      relationTo: Media.slug,
+    },
+  ],
+  hooks: {
+    beforeValidate: [({ data }) => {
+      if (typeof data.title === 'string' && !data.slug) {
+        data.slug = formatSlug(data.title);
+      }
+      return data;
+    }],
+  },
+};
+
+export default Posts;

--- a/collections/Tags.ts
+++ b/collections/Tags.ts
@@ -1,0 +1,32 @@
+import { CollectionConfig } from 'payload/types';
+import { formatSlug } from '../utils/formatSlug';
+
+const Tags: CollectionConfig = {
+  slug: 'tags',
+  admin: {
+    useAsTitle: 'name',
+  },
+  fields: [
+    {
+      name: 'name',
+      type: 'text',
+      required: true,
+    },
+    {
+      name: 'slug',
+      type: 'text',
+      unique: true,
+      required: true,
+    },
+  ],
+  hooks: {
+    beforeValidate: [({ data }) => {
+      if (typeof data.name === 'string' && !data.slug) {
+        data.slug = formatSlug(data.name);
+      }
+      return data;
+    }],
+  },
+};
+
+export default Tags;

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -1,10 +1,22 @@
 import { buildConfig } from 'payload/config';
 import Users from './collections/Users';
+import Media from './collections/Media';
+import Pages from './collections/Pages';
+import Posts from './collections/Posts';
+import Categories from './collections/Categories';
+import Tags from './collections/Tags';
 
 export default buildConfig({
   serverURL: process.env.SERVER_URL || 'http://localhost:3000',
   admin: {
     user: Users.slug,
   },
-  collections: [Users],
+  collections: [
+    Users,
+    Media,
+    Pages,
+    Posts,
+    Categories,
+    Tags,
+  ],
 });

--- a/utils/formatSlug.ts
+++ b/utils/formatSlug.ts
@@ -1,0 +1,6 @@
+export const formatSlug = (value: string): string => {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '');
+};


### PR DESCRIPTION
## Summary
- add Pages, Posts, Categories, Tags and Media collections
- add slug formatting helper
- register new collections in Payload config

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit` *(fails: cannot find module 'payload/types')*

------
https://chatgpt.com/codex/tasks/task_b_68476a7dba1c832d81d958e4835fd961