### PR TITLE
Fix deployment dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ─────────────────────────────────────────────
 
 # Start with a Node base image
-FROM node:18-slim
+FROM node:20-slim
 
 # Set working directory inside container
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -12,18 +12,18 @@
   "author": "Sherafgan Khan",
   "license": "MIT",
   "dependencies": {
-    "@payloadcms/bundler-webpack": "^2.0.0",
-    "@payloadcms/db-mongodb": "^2.0.0",
-    "@payloadcms/plugin-cloud-storage": "^2.0.0",
+    "@payloadcms/bundler-webpack": "^1.0.9",
+    "@payloadcms/db-mongodb": "^3.42.0",
+    "@payloadcms/plugin-cloud-storage": "^3.42.0",
     "dotenv": "^16.3.1",
     "express": "^4.19.2",
     "mongoose": "^8.4.0",
-    "payload": "^2.0.0"
+    "payload": "^3.42.0"
   },
   "devDependencies": {
     "cross-env": "^7.0.3"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20.9.0"
   }
 }


### PR DESCRIPTION
## Summary
- update Payload dependencies to current versions
- switch Node base image to 20-slim
- require Node 20.9+ in `package.json`

## Testing
- `yarn install`

------
https://chatgpt.com/codex/tasks/task_b_684785957a1c832d856062d5273b2b31