### PR TITLE
Fix compose ports and Dockerfile for production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,11 @@ RUN yarn install --non-interactive
 # Copy the rest of the project files
 COPY . .
 
+# Build the production bundle
+RUN yarn build
+
 # Expose the port used by Payload (Next.js)
 EXPOSE 3000
 
-# Start the dev server
-CMD ["yarn", "dev"]
+# Start the app in production mode
+CMD ["yarn", "start"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Edit `.env` to change the admin email, password, or app name if you want.
 docker compose up -d
 ```
 
+MongoDB now exposes port `27018` on the host. If you need to connect to the
+database directly (e.g. using a GUI), use `mongodb://localhost:27018`.
+
 Done.
 Visit:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     volumes:
       - mongo-data:/data/db
     ports:
-      - "27017:27017"
+      # Map to 27018 on the host to avoid conflicts with local MongoDB
+      - "27018:27017"
 
   payload:
     build:
@@ -22,7 +23,7 @@ services:
     depends_on:
       - mongo
     environment:
-      NODE_ENV: development
+      NODE_ENV: production
 
 volumes:
   mongo-data:


### PR DESCRIPTION
## Summary
- set Mongo host port to 27018 in docker-compose to avoid conflicts
- run Payload in production mode and build bundle in Dockerfile
- note new MongoDB port in README

## Testing
- `yarn install` *(passed with warnings)*
- `yarn build` *(failed: Package subpath './config' is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68478a3206d0832db2e75efab1339398