### PR TITLE
Fix build error from open issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@payloadcms/bundler-webpack": "^1.0.9",
     "@payloadcms/db-mongodb": "^3.42.0",
     "@payloadcms/plugin-cloud-storage": "^3.42.0",
+    "@payloadcms/richtext-slate": "^3.42.0",
     "dotenv": "^16.3.1",
     "express": "^4.19.2",
     "mongoose": "^8.4.0",

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -1,4 +1,9 @@
-import { buildConfig } from 'payload/config';
+// Import buildConfig directly from the payload package. Recent versions no
+// longer expose `payload/config` as an export which caused build failures
+// during `docker compose` on production servers.
+import { buildConfig } from 'payload';
+// Default rich text editor; required to avoid build errors in Payload v3.42+
+import { slateEditor } from '@payloadcms/richtext-slate';
 import Users from './collections/Users';
 import Media from './collections/Media';
 import Pages from './collections/Pages';
@@ -11,6 +16,8 @@ export default buildConfig({
   admin: {
     user: Users.slug,
   },
+  // Configure the default rich text editor
+  editor: slateEditor({}),
   collections: [
     Users,
     Media,


### PR DESCRIPTION
## Summary
- use `buildConfig` from `payload` directly
- configure default editor with `@payloadcms/richtext-slate`

## Testing
- `yarn test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_b_6847b7b42a04832db9e239fcab5a72d5