### PR TITLE
Configure bundler for Payload

### DIFF
--- a/payload.config.ts
+++ b/payload.config.ts
@@ -4,6 +4,7 @@
 import { buildConfig } from 'payload';
 // Default rich text editor; required to avoid build errors in Payload v3.42+
 import { slateEditor } from '@payloadcms/richtext-slate';
+import { webpackBundler } from '@payloadcms/bundler-webpack';
 import Users from './collections/Users';
 import Media from './collections/Media';
 import Pages from './collections/Pages';
@@ -12,6 +13,7 @@ import Categories from './collections/Categories';
 import Tags from './collections/Tags';
 
 export default buildConfig({
+  bundler: webpackBundler(),
   serverURL: process.env.SERVER_URL || 'http://localhost:3000',
   admin: {
     user: Users.slug,


### PR DESCRIPTION
## Summary
- import webpackBundler
- enable bundler in Payload config

## Testing
- `yarn build` *(fails: Cannot find module '@swc/core')*

------
https://chatgpt.com/codex/tasks/task_b_6847bb6f0914832da171cd4aebc5f5bd