### PR TITLE
Fix yarn build by adding swc core

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "dotenv": "^16.3.1",
     "express": "^4.19.2",
     "mongoose": "^8.4.0",
-    "payload": "^3.42.0"
+    "payload": "^3.42.0",
+    "@swc/core": "^1.3.91"
   },
   "devDependencies": {
     "cross-env": "^7.0.3"
   },
   "engines": {
     "node": ">=20.9.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Summary
- add `@swc/core` dependency so the Payload build works
- specify `packageManager` to lock to Yarn 1.22.22

## Testing
- `yarn --version`

------
https://chatgpt.com/codex/tasks/task_b_6847c405a4d4832d80ef62e94542d070