### PR TITLE
Switch to Node 18 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 # ─────────────────────────────────────────────
 
 # Start with a Node base image
-FROM node:20-slim
+# Use an LTS version of Node for better compatibility
+FROM node:18-slim
 
 # Set working directory inside container
 WORKDIR /app

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "cross-env": "^7.0.3"
   },
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=18.0.0"
   },
   "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
## Summary
- use Node 18 LTS image for better Payload compatibility
- update engines requirement

## Testing
- `yarn build` *(fails: payload not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847c8fd834c832d8ba36268680f4177