### PR TITLE
Improve Docker build efficiency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ WORKDIR /app
 
 # Install dependencies first for better caching
 COPY package.json ./
-RUN yarn install --non-interactive
+ENV NODE_ENV=production
+RUN yarn install --production --non-interactive && yarn cache clean
 
 # Copy the rest of the project files
 COPY . .


### PR DESCRIPTION
## Summary
- install production dependencies only in Dockerfile

## Testing
- `yarn install --production --ignore-scripts --non-interactive` *(fails: trouble with network connection)*

------
https://chatgpt.com/codex/tasks/task_b_6847e080d33c832daffe8c7fb1afb058