### PR TITLE
Fix build by converting payload config to CommonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Or whatever IP/domain you're using.
 * `Dockerfile`: Builds Payload CMS container
 * `docker-compose.yml`: Spins up both Payload and MongoDB
 * `.env`: All your dumb config variables
-* `payload.config.ts`: Your collections and CMS config go here
+* `payload.config.js`: Your collections and CMS config go here
 * `collections/`: Put your custom content models here
 
 ---

--- a/payload.config.js
+++ b/payload.config.js
@@ -1,18 +1,18 @@
 // Import buildConfig directly from the payload package. Recent versions no
 // longer expose `payload/config` as an export which caused build failures
 // during `docker compose` on production servers.
-import { buildConfig } from 'payload';
+const { buildConfig } = require("payload");
 // Default rich text editor; required to avoid build errors in Payload v3.42+
-import { slateEditor } from '@payloadcms/richtext-slate';
-import { webpackBundler } from '@payloadcms/bundler-webpack';
-import Users from './collections/Users';
-import Media from './collections/Media';
-import Pages from './collections/Pages';
-import Posts from './collections/Posts';
-import Categories from './collections/Categories';
-import Tags from './collections/Tags';
+const { slateEditor } = require('@payloadcms/richtext-slate');
+const { webpackBundler } = require('@payloadcms/bundler-webpack');
+const Users = require('./collections/Users').default;
+const Media = require('./collections/Media').default;
+const Pages = require('./collections/Pages').default;
+const Posts = require('./collections/Posts').default;
+const Categories = require('./collections/Categories').default;
+const Tags = require('./collections/Tags').default;
 
-export default buildConfig({
+module.exports = buildConfig({
   bundler: webpackBundler(),
   serverURL: process.env.SERVER_URL || 'http://localhost:3000',
   admin: {


### PR DESCRIPTION
## Summary
- rename `payload.config.ts` to `payload.config.js`
- switch imports to `require` and export via `module.exports`
- update README to mention the JS config file

## Testing
- `node -c payload.config.js`
- `node -e "console.log(Object.keys(require('./payload.config.js')))"` *(fails: module not found because dependencies are not installed)*


------
https://chatgpt.com/codex/tasks/task_b_6847e743bc38832da251d6086c8afaf1