### PR TITLE
Fix build by enabling ES modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ WORKDIR /app
 # Install dependencies first for better caching
 COPY package.json ./
 ENV NODE_ENV=production
+ENV NODE_OPTIONS="--loader tsx"
 RUN yarn install --production --non-interactive && yarn cache clean
 
 # Copy the rest of the project files

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "keywords": [],
   "author": "Sherafgan Khan",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
     "@payloadcms/bundler-webpack": "^1.0.9",
     "@payloadcms/db-mongodb": "^3.42.0",
@@ -23,7 +24,8 @@
     "@swc/core": "^1.3.91"
   },
   "devDependencies": {
-    "cross-env": "^7.0.3"
+    "cross-env": "^7.0.3",
+    "tsx": "^4.7.0"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "NodeNext",
     "lib": ["DOM", "ESNext"],
     "allowJs": true,
     "checkJs": false,


### PR DESCRIPTION
## Summary
- add `type: module` to package.json
- use NodeNext module type in tsconfig
- use `tsx` loader in Docker
- include `tsx` as devDependency

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_6847ecfc57d8832d889da166586ffcd3