### PR TITLE
Add setup script for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,16 @@ git clone https://github.com/sherafyk/sherafy-payload-stack.git
 cd sherafy-payload-stack
 ```
 
-### 2. Create Your Environment File
+### 2. Install Dependencies (optional)
+
+Run the provided setup script if your environment doesn't already have
+the required packages:
+
+```bash
+./setup.sh
+```
+
+### 3. Create Your Environment File
 
 ```bash
 cp .env.example .env
@@ -40,7 +49,7 @@ cp .env.example .env
 
 Edit `.env` to change the admin email, password, or app name if you want.
 
-### 3. Launch the Stack
+### 4. Launch the Stack
 
 ```bash
 docker compose up -d

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+# Install basic packages
+apt-get update && apt-get install -y curl git
+
+# Enable corepack so yarn is available
+corepack enable
+
+# Install project dependencies
+yarn install


### PR DESCRIPTION
## Summary
- add simple `setup.sh` script to install system packages and project deps
- mention the script in the README instructions

## Testing
- `./setup.sh` *(fails: trouble with network connection)*

------
https://chatgpt.com/codex/tasks/task_b_6848686575b4832da0d123103d4451ac