### PR TITLE
Add GHCR workflow and server runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Build and Push to GHCR
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ github.repository }}:latest
+          build-args: |
+            PAYLOAD_SECRET=${{ secrets.PAYLOAD_SECRET }}
+            MONGODB_URI=${{ secrets.MONGODB_URI }}
+            ADMIN_EMAIL=${{ secrets.ADMIN_EMAIL }}
+            ADMIN_PASSWORD=${{ secrets.ADMIN_PASSWORD }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,19 @@ FROM node:18-slim
 # Set working directory inside container
 WORKDIR /app
 
+# Allow secrets to be injected at build time
+ARG PORT=3000
+ARG PAYLOAD_SECRET
+ARG MONGODB_URI
+ARG ADMIN_EMAIL
+ARG ADMIN_PASSWORD
+
+ENV PORT=$PORT \
+    PAYLOAD_SECRET=$PAYLOAD_SECRET \
+    MONGODB_URI=$MONGODB_URI \
+    ADMIN_EMAIL=$ADMIN_EMAIL \
+    ADMIN_PASSWORD=$ADMIN_PASSWORD
+
 # Install dependencies first for better caching
 COPY package.json yarn.lock ./
 RUN yarn install --non-interactive && yarn cache clean

--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ Or whatever IP/domain you're using.
 
 ---
 
+## Using the GHCR Image
+
+GitHub Actions builds this repo's Docker image and publishes it to
+GitHub Container Registry (GHCR). If you just want to deploy without building
+anything on your server, log in and pull the image:
+
+```bash
+# authenticate to GHCR (use a PAT if your registry is private)
+echo $CR_PAT | docker login ghcr.io -u <github-username> --password-stdin
+
+# pull the latest build
+docker pull ghcr.io/<OWNER>/<REPO>:latest
+
+# run it on any port you like
+docker run -d -p 2501:3000 \
+  -e PAYLOAD_SECRET=... \
+  -e MONGODB_URI=... \
+  ghcr.io/<OWNER>/<REPO>:latest
+```
+
+Replace the environment variables with the same values you use in `.env`.
+
+---
+
 ## Structure
 
 * `Dockerfile`: Builds Payload CMS container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,12 @@ services:
       - "27018:27017"
 
   payload:
-    build:
-      context: .
-      dockerfile: Dockerfile
+    # Use the prebuilt image from GHCR in production.
+    image: ghcr.io/<OWNER>/<REPO>:latest
+    # Uncomment the lines below to build locally instead.
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
     container_name: payload-app
     restart: unless-stopped
     env_file:

--- a/server.js
+++ b/server.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import payload from 'payload';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const app = express();
+
+const start = async () => {
+  await payload.init({
+    secret: process.env.PAYLOAD_SECRET,
+    mongoURL: process.env.MONGODB_URI,
+    express: app,
+  });
+
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server running on port ${port}`);
+  });
+};
+
+start();


### PR DESCRIPTION
## Summary
- add custom `server.js` for Payload bootstrapping
- allow secrets to be baked into Docker image
- publish image to GHCR via GitHub Actions
- default docker-compose to pull from GHCR
- document how to run the prebuilt image

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_684894597eac832d92da864498496dd6