### PR TITLE
Fix Payload init and listening host

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import payload from 'payload';
 import dotenv from 'dotenv';
+import payloadConfig from './payload.config.ts';
 
 dotenv.config();
 
@@ -11,10 +12,11 @@ const start = async () => {
     secret: process.env.PAYLOAD_SECRET,
     mongoURL: process.env.MONGODB_URI,
     express: app,
+    config: payloadConfig,
   });
 
   const port = process.env.PORT || 3000;
-  app.listen(port, () => {
+  app.listen(port, '0.0.0.0', () => {
     console.log(`Server running on port ${port}`);
   });
 };


### PR DESCRIPTION
## Summary
- load `payload.config.ts` when starting the server
- bind the server to `0.0.0.0` so the container port is reachable

## Testing
- `yarn test` *(fails: command not found)*
- `yarn lint` *(fails: command not found)*
- `yarn install`
- `NODE_OPTIONS='--import tsx' node server.js` *(fails: missing secret key)*

------
https://chatgpt.com/codex/tasks/task_b_6848a9d27d48832db801fad5ddd61147