### PR TITLE
Fix startup to load payload config correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ yarn dev
 ```
 
 This starts Payload in development mode using the local MongoDB defined in your `.env` file.
-Use `yarn build && yarn start` when you're ready for production.
+Use `yarn build && yarn start` when you're ready for production. The `start`
+script automatically loads TypeScript via `tsx`, so no manual compilation is
+required.
 
 Once everything is running, visit:
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "cross-env NODE_ENV=development payload dev",
     "build": "payload build",
-    "start": "node server.js"
+    "start": "NODE_OPTIONS=\"--import tsx\" node server.js"
   },
   "keywords": [],
   "author": "Sherafgan Khan",


### PR DESCRIPTION
## Summary
- use tsx loader when running server in production
- document tsx loader in README

## Testing
- `yarn start` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_b_6848b3bea56c832dab8029223e837b53