### PR TITLE
Fix payload config initialization

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,9 +1,7 @@
+import 'dotenv/config';
 import express from 'express';
 import payload from 'payload';
-import dotenv from 'dotenv';
-
-dotenv.config();
-const payloadConfig = (await import('./payload.config.ts')).default;
+import payloadConfig from './payload.config.ts';
 
 const app = express();
 


### PR DESCRIPTION
## Summary
- load environment variables before importing the Payload config
- import the config statically and pass it to `payload.init`

## Testing
- `NODE_OPTIONS="--import tsx" node server.js` *(fails: cannot connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_b_684906622930832daef27db765561af3